### PR TITLE
Turn links on 360doc to be clickable

### DIFF
--- a/userscript.js
+++ b/userscript.js
@@ -19,7 +19,8 @@
 // @match          https://docs.qq.com/scenario/link.html?url=*
 // @match          https://www.pixiv.net/jump.php?url=*
 // @match          https://www.chinaz.com/go.shtml?url=*
-// @version        0.7.10
+// @match          http://www.360doc.com/content/*
+// @version        0.7.11
 // @run-at         document-idle
 // @namespace      https://old-panda.com/
 // @require        https://cdn.bootcdn.net/ajax/libs/jquery/3.5.1/jquery.min.js
@@ -156,12 +157,13 @@
     yy: 'http://redir.yy.duowan.com/warning.php?url=',
     csdn: 'https://link.csdn.net/?target=',
     steam: 'https://steamcommunity.com/linkfilter/?url=',
-    gamebilibili:'game.bilibili.com/linkfilter/?url=',
+    gamebilibili: 'game.bilibili.com/linkfilter/?url=',
     oschina: 'https://www.oschina.net/action/GoToLink?url=',
-    weixindev:'https://developers.weixin.qq.com/community/middlepage/href?href=',
+    weixindev: 'https://developers.weixin.qq.com/community/middlepage/href?href=',
     qqdocs: 'https://docs.qq.com/scenario/link.html?url=',
     pixiv: 'https://www.pixiv.net/jump.php?url=',
-    chinaz: 'https://www.chinaz.com/go.shtml?url='
+    chinaz: 'https://www.chinaz.com/go.shtml?url=',
+    doc360: 'http://www.360doc.com/content/'
   }
 
   $(document).ready(function () {
@@ -205,14 +207,17 @@
     if (match(fuckers.weixindev)) {
       redirect(curURL, "href");
     }
-    if (match(fuckers.qqdocs)){
-      redirect(curURL, "url")
+    if (match(fuckers.qqdocs)) {
+      redirect(curURL, "url");
     }
-    if (match(fuckers.pixiv)){
-      redirect(curURL, "url")
+    if (match(fuckers.pixiv)) {
+      redirect(curURL, "url");
     }
-    if (match(fuckers.chinaz)){
-      redirect(curURL, "url")
+    if (match(fuckers.chinaz)) {
+      redirect(curURL, "url");
+    }
+    if (match(fuckers.doc360)) {
+      $("#articlecontent table tbody tr td#artContent").find("a").off("click");
     }
   });
 


### PR DESCRIPTION
Per request of
<blockquote>您好，发现不支持360图书馆自动跳转链接http://www.360doc.com/content/19/0405/19/62725930_826640109.shtml<br>限制了需要手动点击一次
        <div class="user-screenshots">
      <a href="https://greasyfork.s3.us-east-2.amazonaws.com/boaoqe7uwhrspw9lsh8u16uvzzvj"><img src="https://greasyfork.s3.us-east-2.amazonaws.com/qw6j1u8wy0gwqci0z0veog51sae7"></a>
  </div></blockquote>
at https://greasyfork.org/zh-CN/scripts/412612-open-the-f-king-url-right-now/discussions/77104