### PR TITLE
match zhihu2's url

### DIFF
--- a/userscript.js
+++ b/userscript.js
@@ -6,6 +6,7 @@
 // @match          https://weibo.cn/sinaurl?*
 // @match          https://www.jianshu.com/go-wild?*
 // @match          https://link.zhihu.com/?*
+// @match          http://link.zhihu.com/?*
 // @match          https://www.douban.com/link2/?url=*
 // @match          https://link.ld246.com/forward?goto=*
 // @match          https://mp.weixin.qq.com/*


### PR DESCRIPTION
注意到 #23 移除了对 `http://link.zhihu.com` 域名的支持。实际上知乎上仍有很多链接是指向 http 域名的，我已多次遇到不能跳转的情况。这一 match 不能被去除。