### PR TITLE
修复微博链接匹配规则重复的问题

### DIFF
--- a/userscript.js
+++ b/userscript.js
@@ -197,8 +197,8 @@ const $ = jQuery.noConflict(true);
    */
   const fuckers = {
     weibo: { match: 'http://t.cn/', redirect: function () { const link = $(".wrap .link").first().text() || document.querySelector('.open-url').children[0].href; window.location.replace(link); } }, // 微博网页版
-    weibo_2: { match: 'https://weibo.cn/sinaurl?', redirect: "u"},
-    weibo_3: { match: 'https://weibo.cn/sinaurl?', redirect: "toasturl"},
+    weibo_2: { match: 'https://weibo.cn/sinaurl?u', redirect: "u"},
+    weibo_3: { match: 'https://weibo.cn/sinaurl?toasturl', redirect: "toasturl"},
     weibo_4: { match: 'https://weibo.cn/sinaurl?', redirect: function () { const link = $(".wrap .link").first().text() || document.querySelector('.open-url').children[0].href; window.location.replace(link); } },
     // http://t.cn/RgAKoPE
     // https://weibo.cn/sinaurl?u=https%3A%2F%2Fwww.freebsd.org%2F


### PR DESCRIPTION
#72 非常抱歉，没注意到规则的匹配方式，感谢 @Young-Lord 指出问题，现在测试了一下所有链接应该都能匹配到了，不过我在浏览器访问没存在“安全风险”的URL比如```https://weibo.cn/sinaurl?u=neverssl.com```，会被自动跳转到```https://weibo.cn/pub/```，这应该是平台的问题，希望有人测试一下。