### PR TITLE
docs.qq.com bug 修复

### DIFF
--- a/userscript.js
+++ b/userscript.js
@@ -14,6 +14,7 @@
 // @match          https://blog.51cto.com/transfer?*
 // @match          https://developers.weixin.qq.com/community/middlepage/href?href=*
 // @match          https://docs.qq.com/scenario/link.html?url=*
+// @match          https://docs.qq.com/scenario/link.html?u=*
 // @match          https://game.bilibili.com/linkfilter/?url=*
 // @match          https://gitee.com/link?target=*
 // @match          https://jump2.bdimg.com/safecheck/index?url=*


### PR DESCRIPTION
从 docs.qq.com 打开外链的过程如下：
步骤 1：新建标签页，url 为 docs.qq.com?u=xxx
步骤 2：url 跳转为 为 docs.qq.com?url=xxx
也许是因为采用了 single-page application(单页应用) 的技术，Tampermonkey 无法监听到 url 跳转的过程。 我尝试添加了对步骤 1 中 url 的匹配，测试发现可以成功跳转。