### PR TITLE
Improve c.pc.qq.com

### DIFF
--- a/userscript.js
+++ b/userscript.js
@@ -93,6 +93,7 @@ const fuckers = {
   pixiv: { match: 'https://www.pixiv.net/jump.php?url=', redirect: "url" },
   qcc: { match: 'https://www.qcc.com/web/transfer-link?link=', redirect: "link" },
   qq: { match: 'https://c.pc.qq.com/(middlem|index).html', redirect: "pfurl", enableRegex: true },
+  qqios: { match: 'https://c.pc.qq.com/ios.html', redirect: "url"},
   qqdocs: { match: 'https://docs.qq.com/scenario/link.html?url=', redirect: "url" },
   qqmail: { match: 'https://mail.qq.com/cgi-bin/readtemplate', redirect: "gourl" },
   sspai: { match: 'https://sspai.com/link?target=', redirect: "target" },


### PR DESCRIPTION
I encountered `https://c.pc.qq.com/ios.html` when using PC QQ. It seems to be shared from an ios client and has a different format. Anyway add it to bypass QQ URL hijack.