### PR TITLE
fix pixiv

### DIFF
--- a/userscript.js
+++ b/userscript.js
@@ -48,7 +48,7 @@
 // @match          https://www.mcbbs.net/plugin.php?id=link_redirect&target=*
 // @match          https://www.nodeseek.com/jump?to=*
 // @match          https://www.oschina.net/action/GoToLink?url=*
-// @match          https://www.pixiv.net/jump.php?url=*
+// @match          https://www.pixiv.net/jump.php?*
 // @match          https://www.qcc.com/web/transfer-link?link=*
 // @match          https://www.tianyancha.com/security?target=*
 // @match          https://www.yuque.com/r/goto?url=*
@@ -96,7 +96,7 @@ const fuckers = {
   nga2: { match: 'https://bbs.nga.cn/read.php?', redirect: function () { $("#m_posts #m_posts_c a").prop("onclick", null).off("click") } },
   nodeseek: { match: 'https://www.nodeseek.com/jump?to=', redirect: "to" },
   oschina: { match: 'https://www.oschina.net/action/GoToLink?url=', redirect: "url" },
-  pixiv: { match: 'https://www.pixiv.net/jump.php?url=', redirect: "url" },
+  pixiv: { match: 'https://www.pixiv.net/jump.php?', redirect: function () { window.location.href = decodeURIComponent(curURL.match(/jump.php\?[url=]*(.*)/)[1].replace(/=$/, '')) } },
   qcc: { match: 'https://www.qcc.com/web/transfer-link?link=', redirect: "link" },
   qq: { match: 'https://c.pc.qq.com/(middleb|middlem|index).html', redirect: "pfurl", enableRegex: true },
   qqios: { match: 'https://c.pc.qq.com/ios.html', redirect: "url" },


### PR DESCRIPTION
Close #108 

Pixiv 的跳转页使用了 `referrer` 检测，非本站点击会在网址尾部加上 `=` ，所以用了 `replace` 函数

使用正则兼容了之前带有 url 参数的情况

示例链接

https://pixiv.net/jump.php?https%3A%2F%2Fgithub.com%2FOldPanda%2FOpen-the-F-king-URL-Right-Now

https://pixiv.net/jump.php?url=https%3A%2F%2Fgithub.com%2FOldPanda%2FOpen-the-F-king-URL-Right-Now
