### PR TITLE
feat: support Google AI Studio

### DIFF
--- a/userscript.js
+++ b/userscript.js
@@ -66,7 +66,7 @@
 // @match          https://www.curseforge.com/linkout?remoteUrl=*
 // @match          https://www.douban.com/link2/?url=*
 // @match          https://www.gcores.com/link?target=*
-// @match          https://www.google.com/url?q=*
+// @match          https://www.google.com/url?*
 // @match          https://www.instagram.com/linkshim/?u=*
 // @match          https://www.jianshu.com/go-wild?*
 // @match          https://www.kdocs.cn/etapps/query/link?target=*
@@ -125,7 +125,7 @@ const fuckers = {
   gcores: { match: 'https://www.gcores.com/link?target=', redirect: "target" },
   gitcode: { match: 'https://link.gitcode.com/?target=', redirect: "target" },
   gitee: { match: 'https://gitee.com/link?target=', redirect: "target" },
-  google: { match: 'https://www.google.com/url?q=', redirect: "q" },
+  google: { match: 'https://www\\.google\\.com/url\\?(sa=E&)?q=', redirect: "q", enableRegex: true },
   hellogithub: { match: 'https://hellogithub.com/periodical/statistics/click?target=', redirect: "target" },
   himcbbs: { match: 'https://api.himcbbs.com/refer/?url=', redirect: "url" },
   infoq: { match: 'https://(xie.infoq.cn/link|www.infoq.cn/link)?target=', redirect: "target", enableRegex: true },


### PR DESCRIPTION
Add support for source links for Google AI Studio.

Example URL: `https://www.google.com/url?sa=E&q=https%3A%2F%2Fvertexaisearch.cloud.google.com%2Fgrounding-api-redirect%2FAUZIYQEY-SX08oYRvBxmGrVAT9Ht98jq2bzt5qwrUdtQuxQqdhwJ10K_ZK_9QZxehsuW2T-qsdOwvdpDsVjq_mZ7Re3vt1Mj-W8n0pkFysqHQRCurqapI8KQ_jMoOSy9FxGJqp7GnuX_LlgJPgYIkms-G3LdQhycvPM1_jnv57LSdDoGXJWQGG6oyx-1eRIoj1d4E-C-OmjGnbJ2aVPBlLYmtNiQn9i6SI0Kal7hm889d5FQMk8lr34s4A%3D%3D`