### PR TITLE
fix: fix qq2

### DIFF
--- a/userscript.js
+++ b/userscript.js
@@ -154,7 +154,7 @@ const fuckers = {
   pixiv: { match: 'https://www.pixiv.net/jump.php?', redirect: function () { window.location.href = decodeURIComponent(curURL.match(/jump.php\?[url=]*(.*)/)[1].replace(/=$/, '')) } },
   qcc: { match: 'https://www.qcc.com/web/transfer-link?link=', redirect: "link" },
   qq: { match: 'https://c.pc.qq.com/(middleb|middlect|middlem|index).html', redirect: "pfurl", enableRegex: true },
-  qq2: { match: 'https://c.pc.qq.com/(ios|pc|android).html', redirect: "url", enableRegex: true },
+  qq2: { match: 'https://c.pc.qq.com/(ios|pc|android).html', redirect: function () { window.location.href = window.location.href.replace("https://c.pc.qq.com/ios.html?level=14&url=", "") }, enableRegex: true },
   qqdocs: { match: 'https://docs.qq.com/scenario/link.html?url=', redirect: "url" },
   qqmail: { match: 'https://mail.qq.com/cgi-bin/readtemplate', redirect: "gourl" },
   qqmailwx: { match: 'https://wx.mail.qq.com/xmspamcheck/xmsafejump', redirect: "url" },


### PR DESCRIPTION
修复c.pc.qq.com拦截链接

eg: `https://c.pc.qq.com/ios.html?level=14&url=https://miaobi.baidu.com/video/preview?project_id=NVNiNsWsoTuAAdbjWcLlj0HQT6Mk5lbCv-uAnLwM2oQir5KY_6bIEr5AAv0FGROd&type=3&sub_type=1&effect=undefined&from=my&sa=`

before fix: `https://miaobi.baidu.com/video/preview?type=3`

after fix: `https://miaobi.baidu.com/video/preview?project_id=NVNiNsWsoTuAAdbjWcLlj0HQT6Mk5lbCv-uAnLwM2oQir5KY_6bIEr5AAv0FGROd&type=3&sub_type=1&effect=undefined&from=my&sa=`

暂不确定level是否会变动以及作用