### PR TITLE
fix: Leetcode link

### DIFF
--- a/userscript.js
+++ b/userscript.js
@@ -143,7 +143,7 @@ const fuckers = {
   kdocs: { match: 'https://www.kdocs.cn/etapps/query/link?target=', redirect: "target" },
   kook: { match: 'https://www.kookapp.cn/go-wild.html?url=', redirect: "url" },
   latexstudio: { match: 'https://ask.latexstudio.net/go/index?url=', redirect: "url" },
-  leetcode: { match: 'https://leetcode.cn/link/?target', redirect: "target" },
+  leetcode: { match: 'https://leetcode.cn/link/?target', redirect: function () { window.location.replace(curURL.split("target=").pop()) } },
   linkedin: { match: 'https://www.linkedin.com/safety/go?url=', redirect: "url" },
   logonews: { match: 'https://link.logonews.cn/?', redirect: "url" },
   luogu: { match: 'https://www.luogu.com.cn/paste/', redirect: function () { if (document.getElementById("url")) { window.location.href = $("#url").text() } } },
@@ -350,15 +350,9 @@ function removeFwinDialog() {
 function redirect(fakeURLStr, trueURLParam, enableBase64 = false) {
   let fakeURL = new URL(fakeURLStr);
   let trueURL = fakeURL.searchParams.get(trueURLParam);
-  if (trueURL.startsWith(fuckers.wechat1.match)) {
-    // there could be multiple `&`s in url of a wechat link, so all of them
-    // have to be included in the trueURL.
-    trueURL = fakeURL.search.split(`${trueURLParam}=`).pop();
-  } else {
-    if (enableBase64) trueURL = window.atob(trueURL);
-    if (trueURL.indexOf("http://") !== 0 && trueURL.indexOf("https://") !== 0) {
-      trueURL = "https://" + trueURL;
-    }
+  if (enableBase64) trueURL = window.atob(trueURL);
+  if (trueURL.indexOf("http://") !== 0 && trueURL.indexOf("https://") !== 0) {
+    trueURL = "https://" + trueURL;
   }
   trueURL = decodeURIComponent(trueURL)
   window.location.replace(trueURL);


### PR DESCRIPTION
#171 #71 #82

#82 添加的代码中的 BUG，因为 LeetCode 没有给要跳转的 url 做处理所以导致分不清后面的参数是目标网站还是本网站自带的，于是给在最后的跳转时做了个判断，检测到目标链接如果以 `https://mp.weixin.qq.com/s/` 开头就直接从传入的 `redirect` 处暴力截断然后跳转。

https://github.com/OldPanda/Open-the-F-king-URL-Right-Now/blob/1ad7a3533f7bf14386704e44aee56c5f012983d0/userscript.js#L353-L357

感觉没有做处理的网站应该是少数，不应该这么暴力的判断，应该对 LeetCode 做单独处理。

https://www.douban.com/link2/?url=https%3A%2F%2Fmp.weixin.qq.com%2Fs%2FRN82odj1nVJL6zTm42lV5g&link2key=63d54dbb3c

https://www.douban.com/link2/?url=https%3A%2F%2Fmp.weixin.qq.com%2Fs%3F__biz%3DMzU4NDE3MTEyMA%3D%3D%26amp%3Bmid%3D2247489813%26amp%3Bidx%3D1%26amp%3Bsn%3D7f3bc18ca390d85b17655f7164d8e660%26amp%3Bpoc_token%3DHPOHcGmjSPM2bpmgCzZBewgWNGKtyOLDXL7_SVcY&link2key=63d54dbb3c

https://leetcode.cn/link/?target=https://mp.weixin.qq.com/s?__biz=MzU4NDE3MTEyMA==&mid=2247489813&idx=1&sn=7f3bc18ca390d85b17655f7164d8e660