### PR TITLE
feat: support Bilibili york link-middle-page

### DIFF
--- a/userscript.js
+++ b/userscript.js
@@ -64,6 +64,7 @@
 // @match          https://weixin110.qq.com/cgi-bin/mmspamsupport-bin/newredirectconfirmcgi*
 // @match          https://wj.qq.com/s2/*
 // @match          https://www.baike.com/redirect_link?url=*
+// @match          https://www.bilibili.com/york/link-middle-page*
 // @match          https://www.bookmarkearth.com/view/*
 // @match          https://www.chinaz.com/go.shtml?url=*
 // @match          https://www.coolapk.com/link?url=*
@@ -112,6 +113,7 @@ const fuckers = {
   afdian2: { match: 'https://afdian.com/link?target=', redirect: "target" },
   atcoder: { match: 'https://atcoder.jp/jump?url=', redirect: "url" },
   baike: { match: 'https://www.baike.com/redirect_link?url=', redirect: "url" },
+  bilibiliYork: { match: 'https://www.bilibili.com/york/link-middle-page?', redirect: "redirect_url" },
   blzxteam: { match: 'https://blzxteam.com/gowild.htm?url=', redirect: function () { const url = $("div._2VEbEOHfDtVWiQAJxSIrVi_0").first().attr("title"); window.location.href = url } },
   bookmarkearth: { match: 'https://www.bookmarkearth.com/view/', redirect: function () { window.location.replace(document.querySelector("p.link").innerHTML) } },
   chinaz: { match: 'https://www.chinaz.com/go.shtml?url=', redirect: "url" },


### PR DESCRIPTION
至少发现是在B站动态中的外部链接，会被替换为这个跳转页面，不确定是否有其他地方使用此跳转。因路径中带有York字样，因此起名叫做York跳转页。

其规律为，点击动态中的『外部链接』后，进入：

```
https://www.bilibili.com/york/link-middle-page?navhide=1&redirect_url=https%3A%2F%2Fexample.com%2F&r_type=0
```

随后页面执行js，链接重写为：

```
https://www.bilibili.com/york/link-middle-page/pc?navhide=1&redirect_url=https%3A%2F%2Fexample.com%2F&r_type=0
```

这个PR里面只Hook住了第一个链接（因为是第一步跳转），但应该可以满足一般的需求。